### PR TITLE
COM-43

### DIFF
--- a/src/Augmentation.php
+++ b/src/Augmentation.php
@@ -104,19 +104,35 @@ class Augmentation
             }
             if ($granularity === self::GRANULARITY_DAILY) {
                 $dailyData = (array) $data['daily']->data[0];
+                try {
+                    $tz = new \DateTimeZone($data['timezone']);
+                    $dateTime = new \DateTime('@' . $dailyData['time']);
+                    $dateTime->setTimezone($tz);
+                } catch (\Exception $e) {
+                    error_log("Cannot convert date for lat: {$data['latitude']} long: {$data['longitude']} " . $e->getMessage());
+                    continue;
+                }
                 $this->saveData(
                     $data['latitude'],
                     $data['longitude'],
-                    date('Y-m-d', $dailyData['time']),
+                    $dateTime->format('Y-m-d'),
                     $dailyData,
                     $conditions
                 );
             } elseif ($granularity === self::GRANULARITY_HOURLY) {
                 foreach ($data['hourly']->data as $hourlyData) {
+                    try {
+                        $tz = new \DateTimeZone($data['timezone']);
+                        $dateTime = new \DateTime('@' . $hourlyData->time);
+                        $dateTime->setTimezone($tz);
+                    } catch (\Exception $e) {
+                        error_log("Cannot convert time for lat: {$data['latitude']} long: {$data['longitude']} " . $e->getMessage());
+                        continue;
+                    }
                     $this->saveData(
                         $data['latitude'],
                         $data['longitude'],
-                        date('Y-m-d H:i:s', $hourlyData->time),
+                        $dateTime->format('Y-m-d H:i:s'),
                         (array) $hourlyData,
                         $conditions
                     );

--- a/src/CNG/ForecastTools/lib/Forecast.php
+++ b/src/CNG/ForecastTools/lib/Forecast.php
@@ -137,6 +137,9 @@ class Forecast
           trigger_error(__FILE__ . ':L' . __LINE__ . ": $err\n");
           $nice_responses[] = false;
         } else {
+          if (isset($decoded->code) && ($decoded->code === 403)) {
+            throw new \Keboola\DarkSkyAugmentation\InvalidApiKeyException('Invalid API Key used.');
+          }
           $nice_responses[] = $decoded;
         }
       }

--- a/tests/phpunit/AugmentationTest.php
+++ b/tests/phpunit/AugmentationTest.php
@@ -132,16 +132,22 @@ class AugmentationTest extends TestCase
         $this->assertCount(1 + 24 * 3 * 2, $data);
         $location1Count = 0;
         $location2Count = 0;
+        $date1 = 'zzz';
+        $date2 = 'zzz';
         foreach ($data as $row) {
             if ($row[1] == 49.191 && $row[2] == 16.611) {
                 $location1Count++;
+                $date1 = min($date1, $row[3]);
             }
             if ($row[1] == 50.071 && $row[2] == 14.423) {
                 $location2Count++;
+                $date2 = min($date2, $row[3]);
             }
         }
         $this->assertEquals(96, $location1Count);
         $this->assertEquals(48, $location2Count);
+        $this->assertEquals('2016-05-02 00:00:00', $date1);
+        $this->assertEquals('2016-05-01 00:00:00', $date2);
 
         $usage = json_decode(file_get_contents($this->usageFile));
         $this->assertCount(1, $usage);

--- a/tests/phpunit/AugmentationTest.php
+++ b/tests/phpunit/AugmentationTest.php
@@ -82,6 +82,7 @@ class AugmentationTest extends TestCase
             }
         }
         $this->assertEquals(2, $locationCount);
+        $this->assertEquals($data[2][3], $future);
 
         $usage = json_decode(file_get_contents($this->usageFile));
         $this->assertCount(1, $usage);


### PR DESCRIPTION
problem je v tomhle radku https://github.com/keboola/darksky-augmentation/blob/2e2044cd532e72b65351fb42aa0120855e97ab06/src/Augmentation.php#L110

pole time je v doc https://darksky.net/dev/docs popsane jako:
The UNIX time at which this data point begins. minutely data point are always aligned to the top of the minute, hourly data point objects to the top of the hour, and daily data point objects to midnight of the day, all according to the local time zone.

takze pri requestu na https://api.darksky.net/forecast/TOKEN/50.088968,14.437281,2019-11-16T00:00:00

je v `time` je `1573858800`
coz je 2019-11-15T23:00:00+00:00
a v `timezone`  je `Europe/Prague` coz po konverzi
```
date_default_timezone_set('Europe/Prague');
var_dump(date('Y-m-d H:i:s', $timestamp));
```
vraci `string(19) "2019-11-16 00:00:00"`, kdezto soucasny

```
date_default_timezone_set('UTC');
var_dump(date('Y-m-d H:i:s', $timestamp));
```
vraci `string(19) "2019-11-15 23:00:00"`, coz je blbe

Tzn. ze pro mista, ktera jsou v timezone UTC+X to vraci off by one datum.